### PR TITLE
refactor: use "about" instead of "of"

### DIFF
--- a/docs/general/supported-chains/smart-contract-addresses.md
+++ b/docs/general/supported-chains/smart-contract-addresses.md
@@ -1,7 +1,7 @@
 # Smart Contract Addresses
 
 {% hint style="info" %}
-For an explanation of what each smart contract does, see [contracts.md](../../advanced/protocol-overview/contracts.md "mention")
+For an explanation about what each smart contract does, see [contracts.md](../../advanced/protocol-overview/contracts.md "mention")
 {% endhint %}
 
 ## Payment


### PR DESCRIPTION
# Description

This is a test of the auto-comments system.

# Changes

* Refactor the sentence to use "about" instead of "of" when describing a link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined text in the supported smart contract documentation to improve clarity by updating the phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->