### PR TITLE
docs: change xdai to gnosis gateway. xdai is a deprecated alias

### DIFF
--- a/docs/advanced/request-network-sdk/sdk-guides/request-client/configure-the-request-client.md
+++ b/docs/advanced/request-network-sdk/sdk-guides/request-client/configure-the-request-client.md
@@ -11,7 +11,7 @@ The following command creates a new Request Client instance and configures it to
 const web3SignatureProvider = new Web3SignatureProvider(provider);
 const requestClient = new RequestNetwork({
   nodeConnectionConfig: { 
-    baseURL: 'https://xdai.gateway.request.network/' 
+    baseURL: 'https://gnosis.gateway.request.network/' 
   },
   signatureProvider: web3SignatureProvider,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example configuration to use the Gnosis gateway endpoint instead of the xDai gateway endpoint for the Request Client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->